### PR TITLE
Support CPython 3.8

### DIFF
--- a/should_be/core.py
+++ b/should_be/core.py
@@ -103,7 +103,7 @@ def buildFunction(baseFunc, code=None, glbls=None,
     return resf
 
 
-def buildCode(baseCode, argcount=None, kwonlyargcount=None,
+def buildCode(baseCode, argcount=None, posonlyargcount=None, kwonlyargcount=None,
               nlocals=None, stacksize=None, flags=None,
               code=None, consts=None, names=None,
               varnames=None, filename=None, name=None,
@@ -118,6 +118,24 @@ def buildCode(baseCode, argcount=None, kwonlyargcount=None,
     if hasattr(_f, 'func_code'):
         # Python 2.x
         resc = CodeType(argcount or baseCode.co_argcount,
+                        nlocals or baseCode.co_nlocals,
+                        stacksize or baseCode.co_stacksize,
+                        flags or baseCode.co_flags,
+                        code or baseCode.co_code,
+                        consts or baseCode.co_consts,
+                        names or baseCode.co_names,
+                        varnames or baseCode.co_varnames,
+                        filename or baseCode.co_filename,
+                        name or baseCode.co_name,
+                        firstlineno or baseCode.co_firstlineno,
+                        lnotab or baseCode.co_lnotab,
+                        freevars or baseCode.co_freevars,
+                        cellvars or baseCode.co_cellvars)
+    elif hasattr(baseCode, 'co_posonlyargcount'):
+        # Python 3.8
+        resc = CodeType(argcount or baseCode.co_argcount,
+                        posonlyargcount or baseCode.co_posonlyargcount,
+                        kwonlyargcount or baseCode.co_kwonlyargcount,
                         nlocals or baseCode.co_nlocals,
                         stacksize or baseCode.co_stacksize,
                         flags or baseCode.co_flags,

--- a/should_be/tests/test_container_mixin.py
+++ b/should_be/tests/test_container_mixin.py
@@ -7,31 +7,31 @@ class TestContainerMixin(unittest.TestCase):
         self.lst = [1, 2, 3]
 
     def test_should_include_iter(self):
-        err_msg = (r'[a-zA-Z0-9.]+ should have included \[.+?\]'
+        err_msg = (r'[a-zA-Z0-9.()]+ should have included \[.+?\]'
                    r', but did not have items .+')
-        self.assertRaisesRegexp(AssertionError, err_msg,
+        self.assertRaisesRegex(AssertionError, err_msg,
                                 self.lst.should_include, [4])
 
         self.lst.should_include([1, 2, 3])
 
     def test_should_include_item(self):
-        err_msg = (r'[a-zA-Z0-9.]+ should have included .+?'
+        err_msg = (r'[a-zA-Z0-9.()]+ should have included .+?'
                    r', but did not')
-        self.assertRaisesRegexp(AssertionError, err_msg,
+        self.assertRaisesRegex(AssertionError, err_msg,
                                 self.lst.should_include, 4)
 
         self.lst.should_include(3)
 
     def test_shouldnt_include_iter(self):
         err_msg = 'should not have included'
-        self.assertRaisesRegexp(AssertionError, err_msg,
+        self.assertRaisesRegex(AssertionError, err_msg,
                                 self.lst.shouldnt_include, [2, 3])
 
         self.lst.shouldnt_include([4, 5])
 
     def test_shouldnt_include_item(self):
         err_msg = 'should not have included'
-        self.assertRaisesRegexp(AssertionError, err_msg,
+        self.assertRaisesRegex(AssertionError, err_msg,
                                 self.lst.shouldnt_include, 3)
 
         self.lst.shouldnt_include(4)


### PR DESCRIPTION
This fixes issue #4. But I think Python 3.8 also broke `findObjectName`, which I don’t know how to fix right now, thus I’m allowing the regex to match brackets for `(unknown)`.